### PR TITLE
Vibhor

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ movies:
     build: .
     dockerfile: docker/app/Dockerfile
     ports:
-        - "3000:3000"
+        - "0.0.0.0:3000:3000"
     volumes:
         - "./:/opt/movies"
     volumes_from:


### PR DESCRIPTION
Binding to both network interfaces in docker vm so that we can use virtualbox port forwarding to access the server using localhost:3000 on OSX, more info here https://github.com/boot2docker/boot2docker/blob/master/doc/WORKAROUNDS.md
